### PR TITLE
Mouse wheel fix

### DIFF
--- a/package/contents/ui/lib/CRep.qml
+++ b/package/contents/ui/lib/CRep.qml
@@ -54,6 +54,5 @@ Item {
 	MouseArea {
 		anchors.fill: parent
 		onClicked: root.expanded = !root.expanded
-		onWheel: (wheel) => { plasmoid.configuration.enableScrolling ? switchDesktop(wheel) : {} }
 	}
 }

--- a/package/contents/ui/lib/FRep.qml
+++ b/package/contents/ui/lib/FRep.qml
@@ -93,7 +93,6 @@ GridLayout {
 					//TODO maybe add option for this
 					root.expanded = false
 				}
-				onWheel: (wheel) => { plasmoid.configuration.enableScrolling ? switchDesktop(wheel) : {} }
 			}
 		}
 	}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -101,6 +101,15 @@ PlasmoidItem {
 		}
 	}
 
+	MouseArea {
+		id: rootMouseArea
+		anchors.fill: parent
+
+		onWheel: wheel => { plasmoid.configuration.enableScrolling ? switchDesktop(wheel) : {} }
+	}
+
+	compactRepresentation: CRep { }
+
 	compactRepresentation: CRep { }
 
 	fullRepresentation: FRep { }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -110,8 +110,6 @@ PlasmoidItem {
 
 	compactRepresentation: CRep { }
 
-	compactRepresentation: CRep { }
-
 	fullRepresentation: FRep { }
 
 	PagerModel {


### PR DESCRIPTION
Creates one big mouse scroll area instead of smaller, disconnected scroll areas for each `NumberBox`.
Allows the scroll wheel to work when the tip of the mouse pointer is in between two `NumberBox`s.