### PR TITLE
Add support for the kwin Overview on mouse click

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -18,11 +18,16 @@
 			<label>Whether to wrap page when navigating with pager</label>
 			<default>true</default>
 		</entry>
+		<entry name="overviewCompactLayout" type="Bool">
+			<label>Whether to directly open the overview in compact layout</label>
+			<default>false</default>
+		</entry>
 		<entry name="currentDesktopSelected" type="Enum">
-			<label>What to do on left-mouse click on a desktop rectangle.</label>
+			<label>What to do on left-mouse click on current desktop rectangle.</label>
 			<choices>
 				<choice name="DoNothing"/>
 				<choice name="ShowDesktop"/>
+				<choice name="ShowOverview"/>
 			</choices>
 			<default>0</default>
 		</entry>

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -31,6 +31,7 @@ KCM.SimpleKCM {
 	property alias cfg_enableScrolling: enableScrolling.checked
 	property alias cfg_wrapPage: wrapPage.checked
 	property alias cfg_currentDesktopSelected: currentDesktopSelectedBox.currentIndex
+	property alias cfg_overviewCompactLayout: overviewCompactLayout.checked
 	property alias cfg_stayVisible: stayVisible.checked
 
 	Kirigami.FormLayout {
@@ -86,7 +87,13 @@ KCM.SimpleKCM {
 			id: currentDesktopSelectedBox
 			Kirigami.FormData.label: i18n("Selecting current virtual desktop:")
 
-			model: ["Does nothing", "Shows the desktop"]
+			model: ["Does nothing", "Shows the desktop", "Shows overview"]
+		}
+
+		QtControls.CheckBox {
+			id: overviewCompactLayout
+			enabled: cfg_currentDesktopSelected === 2
+			text: i18n("Directly open overview in compact layout")
 		}
 	}
 }

--- a/package/contents/ui/lib/CRep.qml
+++ b/package/contents/ui/lib/CRep.qml
@@ -53,7 +53,13 @@ Item {
 	}
 	MouseArea {
 		anchors.fill: parent
-		onClicked: root.expanded = !root.expanded
+		onClicked: {
+			if (plasmoid.configuration.overviewCompactLayout) {
+				runOverview()
+			} else {
+				root.expanded = !root.expanded
+			}
+		}
 		onWheel: (wheel) => { plasmoid.configuration.enableScrolling ? switchDesktop(wheel) : {} }
 	}
 }

--- a/package/contents/ui/lib/FRep.qml
+++ b/package/contents/ui/lib/FRep.qml
@@ -89,7 +89,11 @@ GridLayout {
 			MouseArea {
 				anchors.fill: parent
 				onClicked: {
-					pagerModel.changePage(model.index)
+					if (plasmoid.configuration.currentDesktopSelected === 2 && model.index === pagerModel.currentPage) {
+						runOverview()
+					} else {
+						pagerModel.changePage(model.index)
+					}
 					//TODO maybe add option for this
 					root.expanded = false
 				}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -25,12 +25,13 @@ import org.kde.plasma.plasmoid
 import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.components as PlasmaComponents
 import org.kde.kquickcontrolsaddons as KQuickControlsAddonsComponents
-import org.kde.plasma.core as PlasmaCore
 import org.kde.kirigami as Kirigami
 
 import org.kde.plasma.private.pager
 import org.kde.kcmutils as KCM
 import org.kde.config as KConfig
+
+import org.kde.plasma.plasma5support as Plasma5Support
 
 import "./lib"
 
@@ -63,6 +64,10 @@ PlasmoidItem {
 
 	function action_openKCM() {
 		KQuickControlsAddonsComponents.KCMShell.openSystemSettings("kcm_kwin_virtualdesktops");
+	}
+
+	function runOverview() {
+		executable.exec('qdbus org.kde.kglobalaccel /component/kwin invokeShortcut Overview')
 	}
 
 	function switchDesktop(wheel) {
@@ -116,6 +121,19 @@ PlasmoidItem {
 		screenGeometry: root.screenGeometry
 
 		pagerType: PagerModel.VirtualDesktops
+	}
+
+	Plasma5Support.DataSource {
+		id: executable
+		engine: "executable"
+		connectedSources: []
+		onNewData: function(source, data) {
+			disconnectSource(source)
+		}
+
+		function exec(cmd) {
+			executable.connectSource(cmd)
+		}
 	}
 
     Plasmoid.contextualActions: [


### PR DESCRIPTION
Add config options to launch the kwin Overview on mouse click.
The kwin Overview must be enabled in settings for this to work.